### PR TITLE
re-enable compiling libledscape.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARGETS += opc-server
 LEDSCAPE_OBJS = ledscape.o pru.o util.o lib/cesanta/frozen.o lib/cesanta/mongoose.o
 LEDSCAPE_LIB := libledscape.a
 
-all: $(TARGETS) nop_0.bin nop_1.bin ws281x_0.bin ws281x_1.bin dmx_0.bin ws2801_0.bin ws2801_1.bin ws2801_newpins_0.bin ws2801_newpins_1.bin
+all: $(TARGETS) $(LEDSCAPE_LIB) nop_0.bin nop_1.bin ws281x_0.bin ws281x_1.bin dmx_0.bin ws2801_0.bin ws2801_1.bin ws2801_newpins_0.bin ws2801_newpins_1.bin
 
 
 ifeq ($(shell uname -m),armv7l)
@@ -48,7 +48,7 @@ LDLIBS += \
 	-lpthread \
 
 COMPILE.o = $(CROSS_COMPILE)gcc $(CFLAGS) -c -o $@ $<
-COMPILE.a = $(CROSS_COMPILE)gcc -c -o $@ $<
+COMPILE.a = $(CROSS_COMPILE)ar crv $@ $^
 COMPILE.link = $(CROSS_COMPILE)gcc $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 
@@ -80,6 +80,10 @@ PASM := $(PASM_DIR)/pasm
 
 %.o: %.c
 	$(COMPILE.o)
+
+libledscape.a: $(LEDSCAPE_OBJS)
+	$(RM) $@
+	$(COMPILE.a)
 
 $(foreach O,$(TARGETS),$(eval $O: $O.o $(LEDSCAPE_OBJS) $(APP_LOADER_LIB)))
 


### PR DESCRIPTION
while LEDSCAPE_LIB is declared in the Makefile, it is currently not created by the build process.

doing this, i can build other things from outside the LEDscape directory, manually specifying the -I../LEDscape for compiling and -L../LEDscape -lledscape  -L../LEDscape/am335x/app_loader/lib -lprussdrv for the library. much better than having to mix my files inside the LEDscape directory. ideally the libraries could be installed system wide, but that is definitely over my know how of compiling system level stuff.

i still need to symlink / copy my program into LEDscape because the ledscape.c loads .bin files from pwd. again, i don't know how to fix that without getting very complicated.

btw, the reasoning why i want this is to build a little program that i can run on system boot to switch the leds on as soon as possible. at the end of boot, i start opc-server (without demo mode) and wait for services to connect to me.
