### PR TITLE
Change standard to gnu99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ export CROSS_COMPILE?=arm-linux-gnueabi-
 endif
 
 CFLAGS += \
-	-std=c99 \
+	-std=gnu99 \
 	-W \
 	-Wall \
 	-D_DEFAULT_SOURCE \


### PR DESCRIPTION
SRC files wouldn't compile with the vanilla Makefile. (c99 <> gnu99)