### PR TITLE
Adjust reset timing for new WS2812 chip

### DIFF
--- a/pru/templates/ws281x.p
+++ b/pru/templates/ws281x.p
@@ -183,9 +183,9 @@ FRAME_DONE:
 	WAITNS 1200, end_of_frame_clear_wait
 	GPIO_APPLY_MASK_TO_ADDR()
 
-	// Delay at least 50 usec; this is the required reset
+	// Delay at least 300 usec; this is the required reset
 	// time for the LED strip to update with the new pixels.
-	SLEEPNS 50000, 1, reset_time
+	SLEEPNS 300000, 1, reset_time
 
 	// Write out that we are done!
 	// Store a non-zero response in the buffer so that they know that we are done


### PR DESCRIPTION
The old chips required a 50 microsecond reset; the new ones require 300.

See
https://blog.adafruit.com/2017/05/03/psa-the-ws2812b-rgb-led-has-been-revised-will-require-code-tweak/