### PR TITLE
Re-add -D_BSD_SOURCE line to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ CFLAGS += \
 	-std=c99 \
 	-W \
 	-Wall \
+	-D_BSD_SOURCE \
 	-D_DEFAULT_SOURCE \
 	-Wp,-MMD,$(dir $@).$(notdir $@).d \
 	-Wp,-MT,$@ \


### PR DESCRIPTION
`_DEFAULT_SOURCE` replaces `_BSD_SOURCE` in glibc 2.19. However, the "Debian 7.11 2015-06-15 4GB SD LXDE" image referenced in the instructions has glibc 2.13. Keeping both lines in the Makefile should preserve compatibility for all versions of glibc.

#53 is the reference issue, and [this](https://github.com/Yona-Appletree/LEDscape/commit/47d267c3a9a6a988356cbef6c9941d29bbdddb8b) is the commit that introduced the issue.

(#57 was the original PR, but I accidentally dumped a lot more changes on it.)